### PR TITLE
style: 美化 README 首页并补充技术栈信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,76 @@
 <div align="center">
 
-<img src="https://readme-typing-svg.demolab.com?font=Fira+Code&weight=650&size=32&duration=3500&pause=1000&color=00D4AA&center=true&vCenter=true&width=550&height=40&lines=Hi+there%2C+I'm+YCode;Full-Stack+AI+Engineer;Open+Source+Craftsman" alt="Typing Animation" />
+<img src="https://readme-typing-svg.demolab.com?font=Fira+Code&weight=700&size=30&duration=3200&pause=900&color=00F5D4&center=true&vCenter=true&width=680&height=45&lines=Hi+there%2C+I'm+YCode+%F0%9F%91%8B;Coding+is+my+favorite+debug+mode;Build+bold%2C+ship+fast%2C+stay+curious" alt="Typing Animation" />
 
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=dotnet,csharp,ts,react,nextjs,wpf,docker,github" height="40" />
+  <img src="https://komarev.com/ghpvc/?username=lyq-lin&label=ACCESS%20LOG&style=flat-square&color=00F5D4" alt="Views" />
+  <img src="https://img.shields.io/badge/PROFILE-MODE%3A%20GEEK-111111?style=flat-square&logo=matrix&logoColor=00F5D4" alt="Geek Mode" />
+  <img src="https://img.shields.io/badge/STATUS-ONLINE-00F5D4?style=flat-square&logo=github&logoColor=111111" alt="Status" />
+</p>
+
+</div>
+
+```bash
+> whoami
+YCode / Full-Stack Engineer / Builder
+
+> cat motto.txt
+"Stay curious, go deep, build open."
+
+> ./run --mode=geek
+[OK] Designing cool things...
+[OK] Shipping useful tools...
+[OK] Learning forever...
+```
+
+## ⚡ Tech Stack Matrix
+
+<p align="center">
+  <img src="https://skillicons.dev/icons?i=dotnet,java,mysql,postgresql,redis,rabbitmq,js,ts,vue,react,wpf" />
 </p>
 
 <p align="center">
-  <img src="https://komarev.com/ghpvc/?username=lyq-lin&label=ACCESS%20LOG&style=flat-square&color=00D4AA" alt="Views" />
+  <img src="https://img.shields.io/badge/.NET-512BD4?style=for-the-badge&logo=.net&logoColor=white" />
+  <img src="https://img.shields.io/badge/Java-ED8B00?style=for-the-badge&logo=openjdk&logoColor=white" />
+  <img src="https://img.shields.io/badge/MySQL-4479A1?style=for-the-badge&logo=mysql&logoColor=white" />
+  <img src="https://img.shields.io/badge/PostgreSQL-4169E1?style=for-the-badge&logo=postgresql&logoColor=white" />
+  <img src="https://img.shields.io/badge/Redis-DC382D?style=for-the-badge&logo=redis&logoColor=white" />
+  <img src="https://img.shields.io/badge/RabbitMQ-FF6600?style=for-the-badge&logo=rabbitmq&logoColor=white" />
+  <img src="https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=111111" />
+  <img src="https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white" />
+  <img src="https://img.shields.io/badge/Vue-42B883?style=for-the-badge&logo=vuedotjs&logoColor=white" />
+  <img src="https://img.shields.io/badge/React-61DAFB?style=for-the-badge&logo=react&logoColor=111111" />
+  <img src="https://img.shields.io/badge/WPF-0078D4?style=for-the-badge&logo=windows&logoColor=white" />
 </p>
 
----
+## 🚀 Fun Projects
 
-### 🧠 Current Focus
-
-<table border="0" width="100%">
-  <tr style="border: none;">
-    <td width="50%" align="center" style="border: none;">
+<table>
+  <tr>
+    <td width="50%" align="center">
       <a href="https://github.com/lyq-lin/ycode-cli">
-        <img src="https://img.shields.io/badge/PROJECT-YCode.CLI-00D4AA?style=for-the-badge&logo=terminal&logoColor=white" /><br>
-        <sub><b>Next-gen AI Agent Engine</b></sub><br>
-        <code>.NET 10</code> • <code>ReAct Pattern</code>
+        <img src="https://img.shields.io/badge/PROJECT-YCode.CLI-00F5D4?style=for-the-badge&logo=gnubash&logoColor=111111" /><br>
+        <sub><b>AI Agent CLI Playground</b></sub><br>
+        <code>.NET</code> · <code>CLI</code> · <code>Automation</code>
       </a>
     </td>
-    <td width="50%" align="center" style="border: none;">
+    <td width="50%" align="center">
       <a href="https://github.com/lyq-lin/YCode.Designer.Fluxo">
-        <img src="https://img.shields.io/badge/PROJECT-Designer.Fluxo-0078D4?style=for-the-badge&logo=windows&logoColor=white" /><br>
-        <sub><b>WPF Node Craftsmanship</b></sub><br>
-        <code>XAML Art</code> • <code>Deep UI</code>
+        <img src="https://img.shields.io/badge/PROJECT-Fluxo-7C3AED?style=for-the-badge&logo=windows-terminal&logoColor=white" /><br>
+        <sub><b>Visual Workflow & Node Editor</b></sub><br>
+        <code>WPF</code> · <code>UI/UX</code> · <code>Designer</code>
       </a>
     </td>
   </tr>
 </table>
 
----
+## 🧪 Build Philosophy
 
-### 💡 Philosophy
+- Think like an engineer, craft like an artist.
+- Keep architecture clean, but never boring.
+- Build tools that make developers smile.
 
-> **"Stay curious, go deep, build open."**
-> *I chase emerging tech, master the fundamentals, and share everything.*
+> **"Code should be useful first, elegant second, and always evolving."**
 
 <br>
 
@@ -46,9 +78,7 @@
 
 <br>
 
-<p align="center">
-  <a href="mailto:ycode.4ev@gmail.com"><img src="https://img.shields.io/badge/Email-ycode.4ev@gmail.com-00D4AA?style=flat-square&logo=gmail&logoColor=white" /></a>
+<div align="center">
+  <a href="mailto:ycode.4ev@gmail.com"><img src="https://img.shields.io/badge/Email-ycode.4ev@gmail.com-00F5D4?style=flat-square&logo=gmail&logoColor=white" /></a>
   <a href="https://space.bilibili.com/214520669"><img src="https://img.shields.io/badge/Bilibili-Space-FB7299?style=flat-square&logo=bilibili&logoColor=white" /></a>
-</p>
-
 </div>


### PR DESCRIPTION
### Motivation

- 让个人主页更有极客/终端风格以强化个人品牌展示。 
- 明确突出熟悉的技术栈（如 .NET、Java、MySQL、PostgreSQL、Redis、RabbitMQ、JS/TS、Vue、React、WPF）。
- 突出并美化代表性项目展示（如 `ycode-cli` 与 `YCode.Designer.Fluxo`）。

### Description

- 将 README 头部的动态打字机文案与样式替换为更高对比、极客感的 SVG 动画并新增状态徽章与终端风格区块。 
- 在 `README.md` 中新增 `Tech Stack Matrix`，添加 `skillicons` 行列与为每项技术添加对应的 `shields.io` 徽章。 
- 重设计项目展示区域，统一项目卡片样式并突出 `ycode-cli` 与 `Fluxo` 的简介与链接。 
- 调整哲学、构建理念与联系方式区块的布局与文案以提升整体可读性与视觉一致性（仅修改 `README.md`）。

### Testing

- 通过运行 `git diff -- README.md` 检查差异以验证预期修改，结果显示文档更新。 
- 通过运行 `git status --short` 与 `cat -n README.md` 本地查看工作区与文件内容以确认文件状态与内容正确，均已核验通过。 
- 已在本地对 Markdown 渲染结构进行人工检查以确保语法与布局没有明显破损。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eca2c1ab88332b76696050e997573)